### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/**
 docs/annotated
 npm-debug.log
 docs/coverage.html
+package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -1,46 +1,46 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-> A [Seneca.js](https://www.npmjs.com/package/seneca) logger for Logstash
+> A [Seneca.js][] plugin
 
-# seneca-logstash-logger
+# @seneca/logstash-logger
 
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Dependency Status][david-badge]][david-url]
-[![Coveralls][BadgeCoveralls]][Coveralls]
-[![Gitter][gitter-badge]][gitter-url]
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
+## Install
 
-- __Lead Maintainer__: [David Gonzalez](https://github.com/dgonzalez)
-- __Sponsor__: [nearForm](http://www.nearform.com)
-- __node__: 4.x, 6.x
-
-This module is a plugin that enables your Seneca-based microservice to send logs
-to Logstash via TCP or UDP.
-
-### Seneca compatibility
-
-Supports Seneca versions **2** - **3.x**
-
-## Getting Started
-
-Here is an example on how to use the logger:
-```
-var Seneca = require('seneca')
-
-var logstash = {
-		host: 'localhost',
-		port: 7132,
-		type: 'udp'
-}
-
-var seneca = Seneca({legacy: {logging: false}, 'logstash-logger': logstash})
-seneca.use(require('seneca-logstash-logger'))
+```sh
+npm install seneca-logstash-logger
 ```
 
-And that's all! From now on, all the Seneca log output will be sent to the Logstash
-instance specified by the `host` property of the configuration.
+## Quick Example
 
-## Configuration
+```js
+require('seneca')({
+  legacy: { logging: false }
+})
+.use(require('seneca-logstash-logger'), {
+  logstash: { host: 'localhost', port: 5000 }
+})
+```
+
+## More Examples
+
+See [test/](test/) for usage examples.
+
+## Motivation
+
+A Logstash logger for Seneca microservices. Sends structured log entries to Logstash.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue][]
+- Tweet to [@senecajs][]
+
+## API
+
+### Configuration
 
 In order to configure the logger there is a number of configuration parameters that
 can be passed into Seneca in the key 'logstash-logger'.
@@ -48,30 +48,25 @@ can be passed into Seneca in the key 'logstash-logger'.
 Those parameters are defined by [Node Logstash Client](https://github.com/purposeindustries/node-logstash-client)
 which is the library used by this module to communicate to logstash.
 
-## Running Logstash using Docker
-If you need to spin up a new instance of logstash for testing purposes, the following
-command matches the configuration from the example above:
-
-```
-docker run -it --rm -p 7132:7132 logstash logstash -e 'input { udp { port => 7132} } output { stdout { } }'
-```
-Please note that if you are using docker-machine or any other virtualization
-technology to run Docker you will need to replace `localhost` by the IP of the `docker-machine` (just run `docker-machine ip` in the console).
-
-## Compatibility
-
-seneca-logstash-logger is only compatible with Seneca 3.0+ and Node 4.x+
-
 ## Contributing
 
-The [Senecajs org](https://www.npmjs.com/package/seneca) encourage open participation. If you feel you can help in any way, be it with
-documentation, examples, extra testing, or new features please get in touch.
+The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
 
-## License
+### Running tests
 
-Copyright (c) 2016, David Gonzalez and other contributors.
-Licensed under [MIT](LICENSE).
+```sh
+npm run test
+```
 
+## Background
+
+Compatible with Logstash via UDP. Originally developed by [nearForm](http://nearform.com).
+
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Dependency Status][david-badge]][david-url]
+[![Coveralls][BadgeCoveralls]][Coveralls]
+[![Gitter][gitter-badge]][gitter-url]
 [npm-url]: https://npmjs.com/package/seneca-logstash-logger
 [npm-badge]: https://img.shields.io/npm/v/seneca-logstash-logger.svg
 [travis-badge]: https://travis-ci.org/senecajs/seneca-logstash-logger.svg

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-logstash-logger",
+  "name": "@seneca/logstash-logger",
   "version": "1.0.0",
   "description": "",
   "main": "logstash.js",
@@ -34,9 +34,9 @@
     "seneca": "plugin"
   },
   "files": [
-   "logstash.js",
-   "README.md",
-   "LICENSE"
+    "logstash.js",
+    "README.md",
+    "LICENSE"
   ],
   "pre-commit": [
     "test"


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`
